### PR TITLE
Fixed bug with location metro_area not loading

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    songkickr (0.2.2)
+    songkickr (0.3.1)
       songkickr
 
 GEM

--- a/lib/songkickr/location.rb
+++ b/lib/songkickr/location.rb
@@ -38,7 +38,7 @@ module Songkickr
         @lng  = city_hash["lng"]
       end
       
-      @metro_area = location_hash['metro_area']
+      @metro_area = location_hash['metroArea']
     end
   end
 end

--- a/test/songkickr/test_location.rb
+++ b/test/songkickr/test_location.rb
@@ -14,6 +14,7 @@ class TestLocation < Test::Unit::TestCase
       assert_equal "Potters Bar", potters_bar.city
       assert_equal 51.6833, potters_bar.lat
       assert_equal -0.166667, potters_bar.lng 
+      assert_equal 24426, potters_bar.metro_area["id"]
     end
     
   end  


### PR DESCRIPTION
Fixed problem with metro_area not being loaded for locations by changing location_hash['metro_area'] to the correct location_hash['metroArea']
