### PR TITLE
Add options param to location_search_metro_area_name

### DIFF
--- a/lib/songkickr/remote_api/upcoming_events.rb
+++ b/lib/songkickr/remote_api/upcoming_events.rb
@@ -119,7 +119,7 @@ module Songkickr
       # === Parameters
       # * +metro_area_name+ - Metro area or city named 'location_name' string <em>Ex. 'Minneapolis', 'Nashville', or 'London'</em>.
       # * +options+ - hash of additional options such as page and per_page
-      def location_search_metro_area_name(metro_area_name)
+      def location_search_metro_area_name(metro_area_name, options = {})
         location_search(options.merge(:query => metro_area_name))
       end
 


### PR DESCRIPTION
`location_search_metro_area_name` method throws an NameError because `options` is not defined. This PR passes a default options param so that the method can succeed.