### PR TITLE
Update location search example docs

### DIFF
--- a/lib/songkickr/remote_api/upcoming_events.rb
+++ b/lib/songkickr/remote_api/upcoming_events.rb
@@ -86,8 +86,8 @@ module Songkickr
       #
       # ==== Query Parameters
       # * +name+ - Metro area or city named 'location_name' string <em>Ex. 'Minneapolis', 'Nashville', or 'London'</em>.
-      # * +location+ - 'geo:{lat,lng}' string <em>Ex. 'geo:{-0.128,51.5078}'</em>
-      # * +ip+ - 'ip:{ip-addr}' string <em>Ex. 'ip:{123.123.123.123}'</em>
+      # * +location+ - 'geo:lat,lng' string <em>Ex. 'geo:-0.128,51.5078'</em>
+      # * +ip+ - 'ip:ip-addr' string <em>Ex. 'ip:123.123.123.123'</em>
       # * +page+ - Page number
       # * +per_page+ - Number of results per page, max 50.
       def location_search(query = {})


### PR DESCRIPTION
The examples in the docs for location_search show queries surrounded with braces, but those queries throw an APIError

APIError: Bad request. Please check the documentation: parameter 'location' must be one of the forms: 'geo:-21.22,40.0', 'clientip' or 'ip:127.0.0.1' 

This just updates the documentation.